### PR TITLE
fix(vendas,compras): envolve uso de useSearchParams em Suspense

### DIFF
--- a/src/app/compras/page.tsx
+++ b/src/app/compras/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 import PageBreadcrumb from '@/shared/components/layout/PageBreadCrumb';
 import { useSearchParams } from 'next/navigation';
-import { useEffect, useMemo, useState } from 'react';
+import { Suspense, useEffect, useMemo, useState } from 'react';
 import { useCompras, useItensCompra } from '@/shared/store/useStore';
 import { Modal } from '@/shared/components/ui/modal';
 import { useModal } from '@/shared/hooks/useModal';
@@ -20,6 +20,14 @@ const formatNumeroCompra = (posicaoNaLista: number) =>
   `CMP-${String(posicaoNaLista + 1).padStart(4, '0')}`;
 
 export default function ComprasPage() {
+  return (
+    <Suspense fallback={null}>
+      <ComprasContent />
+    </Suspense>
+  );
+}
+
+function ComprasContent() {
   const { comprasComDetalhes, fetchCompras, deleteCompra } = useCompras();
   const { itensCompra, fetchItensCompra } = useItensCompra();
 

--- a/src/app/vendas/page.tsx
+++ b/src/app/vendas/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 import PageBreadcrumb from '@/shared/components/layout/PageBreadCrumb';
 import { useSearchParams } from 'next/navigation';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { Suspense, useEffect, useMemo, useState } from 'react';
 import { useVendas, useClientes, useItensVenda, useCanaisVenda } from '@/shared/store/useStore';
 import ClienteEnderecoModal from '@/features/vendas/components/ClienteEnderecoModal';
 import NovoCadastroModal from '@/features/vendas/components/NovoCadastroModal';
@@ -31,6 +31,14 @@ const formatNumeroVenda = (posicaoNaLista: number) =>
 const STATUS_CONCLUIDOS = ['Concluída', 'Entregue'] as const;
 
 export default function VendasPage() {
+  return (
+    <Suspense fallback={null}>
+      <VendasContent />
+    </Suspense>
+  );
+}
+
+function VendasContent() {
   const { vendasComDetalhes, fetchVendas, deleteVenda } = useVendas();
   const { clientes, fetchClientes, deleteCliente } = useClientes();
   const { itensVenda, fetchItensVenda } = useItensVenda();


### PR DESCRIPTION
O Next 16 aborta o prerender estatico quando useSearchParams e usado fora de um Suspense boundary (missing-suspense-with-csr-bailout). O conteudo das paginas /vendas e /compras passa a ser renderizado dentro de <Suspense> para permitir o build de producao.